### PR TITLE
Improve XML AST presentation

### DIFF
--- a/src/main/java/net/sourceforge/pmd/util/fxdesigner/util/codearea/syntaxhighlighting/XmlSyntaxHighlighter.java
+++ b/src/main/java/net/sourceforge/pmd/util/fxdesigner/util/codearea/syntaxhighlighting/XmlSyntaxHighlighter.java
@@ -29,8 +29,8 @@ public class XmlSyntaxHighlighter extends SimpleRegexSyntaxHighlighter {
         .or(XML_CDATA_CONTENT.css, "(?<=<!\\[CDATA\\[).*?(?=]]>)")
         .or(XML_PROLOG.css, "<\\?xml.*?\\?>")
         .or(XML_LT_GT.css, "</?|/?>")
-        .or(XML_TAG_NAME.css, "\\b(?<=(</?))\\w[-\\w:]*")
-        .or(XML_ATTRIBUTE_NAME.css, "\\w[-\\w]*(?=\\s*=\\s*[\"'])")
+        .or(XML_TAG_NAME.css, "\\b(?<=(</?))\\w[-.\\w:]*")
+        .or(XML_ATTRIBUTE_NAME.css, "\\w[-.\\w]*(?=\\s*=\\s*[\"'])")
         .or(HighlightClasses.STRING.css, "('([^'<>\\\\]|\\\\.)*')|(\"([^\"<>\\\\]|\\\\.)*\")")
         .create(Pattern.DOTALL);
 

--- a/src/main/java/net/sourceforge/pmd/util/fxdesigner/util/controls/ASTTreeCell.java
+++ b/src/main/java/net/sourceforge/pmd/util/fxdesigner/util/controls/ASTTreeCell.java
@@ -10,6 +10,7 @@ import java.lang.reflect.Modifier;
 import java.util.function.Consumer;
 
 import org.apache.commons.beanutils.PropertyUtils;
+import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.reactfx.value.Val;
 
@@ -201,7 +202,7 @@ public class ASTTreeCell extends TreeCell<Node> {
             setGraphic(null);
             return;
         } else {
-            setText(item.toString() + (item.getImage() == null ? "" : " \"" + item.getImage() + "\""));
+            setText(nodePresentableText(item));
             setContextMenu(buildContextMenu(item));
         }
 
@@ -214,6 +215,11 @@ public class ASTTreeCell extends TreeCell<Node> {
             }
         });
 
+    }
+
+    private static String nodePresentableText(Node node) {
+        String image = node.getImage() == null ? "" : " \"" + StringEscapeUtils.escapeJava(node.getImage()) + "\"";
+        return node.getXPathNodeName() + image;
     }
 
 


### PR DESCRIPTION
* Escape the image of AST nodes when displaying in the treeview. Otherwise the "text" nodes of XML asts display linebreaks and the structure is hard to follow.