### PR TITLE
Add a runnable profile

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,9 +11,9 @@
 #### Clean build from source
 
 * Clone the repository
-* Run `./mvnw clean verify`
-* The artifact can then be found in the `target` directory (it won't include PMD
- dependencies)
+* Run `./mvnw -Pshading clean verify`
+* The artifact can then be found in the `target` directory 
+(it won't include PMD dependencies)
 
 #### IDE Setup
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ If the `bin` directory of your PMD distribution is on your shell's path, then yo
 * `run.sh designer` on Linux/ OSX
 * `designer.bat` on Windows
 
+Alternatively, you can launch the program "from source" with Maven.
+* `$ ./mvnw -Prunning exec:java` will launch the program after compiling it, using the JavaFX distribution of your system
+* `$ ./mvnw -Prunning,with-javafx exec:java` will also add JavaFX dependencies on your classpath.
+You can change the version of those dependencies with eg `-Dopenjfx.version 13` for OpenJFX 13.
+See the list of available versions [here](https://search.maven.org/artifact/org.openjfx/javafx).
+
 ### Updating
 
 The latest version of the designer currently **works with PMD 6.23.0 and above**.

--- a/pmd-ui.iml
+++ b/pmd-ui.iml
@@ -104,23 +104,23 @@
     <orderEntry type="library" scope="RUNTIME" name="Maven: aopalliance:aopalliance:1.0" level="project" />
     <orderEntry type="library" scope="RUNTIME" name="Maven: javax.inject:javax.inject:1" level="project" />
     <orderEntry type="library" scope="RUNTIME" name="Maven: net.sourceforge.pmd:pmd-java:6.23.0" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: net.sourceforge.pmd:pmd-scala:6.23.0" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.scalameta:scalameta_2.13:4.2.0" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.scala-lang:scala-library:2.13.0" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.scalameta:parsers_2.13:4.2.0" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.scalameta:trees_2.13:4.2.0" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.scalameta:common_2.13:4.2.0" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: com.lihaoyi:sourcecode_2.13:0.1.7" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: com.thesamet.scalapb:scalapb-runtime_2.13:0.9.0" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: com.thesamet.scalapb:lenses_2.13:0.9.0" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: com.lihaoyi:fastparse_2.13:2.1.3" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: com.google.protobuf:protobuf-java:3.7.1" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.scalameta:fastparse_2.13:1.0.1" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.scalameta:fastparse-utils_2.13:1.0.1" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.scala-lang:scalap:2.13.0" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.scala-lang:scala-compiler:2.13.0" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.scala-lang:scala-reflect:2.13.0" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: jline:jline:2.14.6" level="project" />
+    <orderEntry type="library" scope="RUNTIME" name="Maven: net.sourceforge.pmd:pmd-scala:6.23.0" level="project" />
+    <orderEntry type="library" scope="RUNTIME" name="Maven: org.scalameta:scalameta_2.13:4.2.0" level="project" />
+    <orderEntry type="library" scope="RUNTIME" name="Maven: org.scala-lang:scala-library:2.13.0" level="project" />
+    <orderEntry type="library" scope="RUNTIME" name="Maven: org.scalameta:parsers_2.13:4.2.0" level="project" />
+    <orderEntry type="library" scope="RUNTIME" name="Maven: org.scalameta:trees_2.13:4.2.0" level="project" />
+    <orderEntry type="library" scope="RUNTIME" name="Maven: org.scalameta:common_2.13:4.2.0" level="project" />
+    <orderEntry type="library" scope="RUNTIME" name="Maven: com.lihaoyi:sourcecode_2.13:0.1.7" level="project" />
+    <orderEntry type="library" scope="RUNTIME" name="Maven: com.thesamet.scalapb:scalapb-runtime_2.13:0.9.0" level="project" />
+    <orderEntry type="library" scope="RUNTIME" name="Maven: com.thesamet.scalapb:lenses_2.13:0.9.0" level="project" />
+    <orderEntry type="library" scope="RUNTIME" name="Maven: com.lihaoyi:fastparse_2.13:2.1.3" level="project" />
+    <orderEntry type="library" scope="RUNTIME" name="Maven: com.google.protobuf:protobuf-java:3.7.1" level="project" />
+    <orderEntry type="library" scope="RUNTIME" name="Maven: org.scalameta:fastparse_2.13:1.0.1" level="project" />
+    <orderEntry type="library" scope="RUNTIME" name="Maven: org.scalameta:fastparse-utils_2.13:1.0.1" level="project" />
+    <orderEntry type="library" scope="RUNTIME" name="Maven: org.scala-lang:scalap:2.13.0" level="project" />
+    <orderEntry type="library" scope="RUNTIME" name="Maven: org.scala-lang:scala-compiler:2.13.0" level="project" />
+    <orderEntry type="library" scope="RUNTIME" name="Maven: org.scala-lang:scala-reflect:2.13.0" level="project" />
+    <orderEntry type="library" scope="RUNTIME" name="Maven: jline:jline:2.14.6" level="project" />
     <orderEntry type="library" scope="RUNTIME" name="Maven: net.sourceforge.pmd:pmd-javascript:6.23.0" level="project" />
     <orderEntry type="library" scope="RUNTIME" name="Maven: org.mozilla:rhino:1.7.7.2" level="project" />
     <orderEntry type="library" scope="RUNTIME" name="Maven: net.sourceforge.pmd:pmd-jsp:6.23.0" level="project" />
@@ -128,7 +128,7 @@
     <orderEntry type="library" scope="RUNTIME" name="Maven: net.sourceforge.pmd:pmd-visualforce:6.23.0" level="project" />
     <orderEntry type="library" scope="RUNTIME" name="Maven: net.sourceforge.pmd:pmd-vm:6.23.0" level="project" />
     <orderEntry type="library" scope="RUNTIME" name="Maven: net.sourceforge.pmd:pmd-xml:6.23.0" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: net.sourceforge.pmd:pmd-modelica:6.23.0" level="project" />
+    <orderEntry type="library" scope="RUNTIME" name="Maven: net.sourceforge.pmd:pmd-modelica:6.23.0" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: net.sourceforge.pmd:pmd-lang-test:6.23.0" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.jetbrains.kotlin:kotlin-stdlib:1.3.0" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.jetbrains.kotlin:kotlin-stdlib-common:1.3.0" level="project" />

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,10 @@
         <java.version>8</java.version>
         <kotlin.version>1.2.61</kotlin.version>
 
+        <!-- Those have different values based on the profile -->
+        <openjfx.scope>provided</openjfx.scope>
+        <pmd.module.scope>runtime</pmd.module.scope>
+
         <local.lib.repo>${project.basedir}/lib/mvn-repo</local.lib.repo>
 
         <surefire.version>3.0.0-M3</surefire.version>
@@ -304,39 +308,6 @@
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.1</version>
-                <configuration>
-
-                    <!-- We can't just use an artifactSet/excludes to exclude pmd dependencies -->
-                    <!-- because it would include their transitive dependencies -->
-
-                    <relocations>
-                        <!-- Relocate apache dependencies because they're included in the binary dist-->
-                        <relocation>
-                            <pattern>org.apache.commons</pattern>
-                            <shadedPattern>org.shaded.apache.commons</shadedPattern>
-                        </relocation>
-                    </relocations>
-
-                    <!-- Merge resource provider files like Ikonli icon resolvers -->
-                    <transformers>
-                        <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
-                    </transformers>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>${javadoc.plugin.version}</version>
                 <configuration>
@@ -408,7 +379,7 @@
                 <artifactId>maven-release-plugin</artifactId>
                 <version>2.5.3</version>
                 <configuration>
-                    <releaseProfiles>release</releaseProfiles>
+                    <releaseProfiles>shading,release</releaseProfiles>
                     <pushChanges>true</pushChanges>
                     <localCheckout>true</localCheckout>
                     <autoVersionSubmodules>true</autoVersionSubmodules>
@@ -456,37 +427,37 @@
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-base</artifactId>
             <version>${openjfx.version}</version>
-            <scope>provided</scope>
+            <scope>${openjfx.scope}</scope>
         </dependency>
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-controls</artifactId>
             <version>${openjfx.version}</version>
-            <scope>provided</scope>
+            <scope>${openjfx.scope}</scope>
         </dependency>
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-fxml</artifactId>
             <version>${openjfx.version}</version>
-            <scope>provided</scope>
+            <scope>${openjfx.scope}</scope>
         </dependency>
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-graphics</artifactId>
             <version>${openjfx.version}</version>
-            <scope>provided</scope>
+            <scope>${openjfx.scope}</scope>
         </dependency>
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-media</artifactId>
             <version>${openjfx.version}</version>
-            <scope>provided</scope>
+            <scope>${openjfx.scope}</scope>
         </dependency>
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-web</artifactId>
             <version>${openjfx.version}</version>
-            <scope>provided</scope>
+            <scope>${openjfx.scope}</scope>
         </dependency>
 
         <!-- Other libraries -->
@@ -568,7 +539,7 @@
             <groupId>net.sourceforge.pmd</groupId>
             <artifactId>pmd-core</artifactId>
             <version>${pmd.core.version}</version>
-            <scope>provided</scope>
+            <scope>compile</scope>
         </dependency>
 
         <dependency>
@@ -576,70 +547,70 @@
             <artifactId>pmd-apex</artifactId>
             <version>${pmd.core.version}</version>
             <optional>true</optional>
-            <scope>provided</scope>
+            <scope>${pmd.module.scope}</scope>
         </dependency>
         <dependency>
             <groupId>net.sourceforge.pmd</groupId>
             <artifactId>pmd-java</artifactId>
             <version>${pmd.core.version}</version>
             <optional>true</optional>
-            <scope>provided</scope>
+            <scope>${pmd.module.scope}</scope>
         </dependency>
         <dependency>
             <groupId>net.sourceforge.pmd</groupId>
             <artifactId>pmd-scala</artifactId>
             <version>${pmd.core.version}</version>
             <optional>true</optional>
-            <scope>provided</scope>
+            <scope>${pmd.module.scope}</scope>
         </dependency>
         <dependency>
             <groupId>net.sourceforge.pmd</groupId>
             <artifactId>pmd-javascript</artifactId>
             <version>${pmd.core.version}</version>
             <optional>true</optional>
-            <scope>provided</scope>
+            <scope>${pmd.module.scope}</scope>
         </dependency>
         <dependency>
             <groupId>net.sourceforge.pmd</groupId>
             <artifactId>pmd-jsp</artifactId>
             <version>${pmd.core.version}</version>
             <optional>true</optional>
-            <scope>provided</scope>
+            <scope>${pmd.module.scope}</scope>
         </dependency>
         <dependency>
             <groupId>net.sourceforge.pmd</groupId>
             <artifactId>pmd-plsql</artifactId>
             <version>${pmd.core.version}</version>
             <optional>true</optional>
-            <scope>provided</scope>
+            <scope>${pmd.module.scope}</scope>
         </dependency>
         <dependency>
             <groupId>net.sourceforge.pmd</groupId>
             <artifactId>pmd-visualforce</artifactId>
             <version>${pmd.core.version}</version>
             <optional>true</optional>
-            <scope>provided</scope>
+            <scope>${pmd.module.scope}</scope>
         </dependency>
         <dependency>
             <groupId>net.sourceforge.pmd</groupId>
             <artifactId>pmd-vm</artifactId>
             <version>${pmd.core.version}</version>
             <optional>true</optional>
-            <scope>provided</scope>
+            <scope>${pmd.module.scope}</scope>
         </dependency>
         <dependency>
             <groupId>net.sourceforge.pmd</groupId>
             <artifactId>pmd-xml</artifactId>
             <version>${pmd.core.version}</version>
             <optional>true</optional>
-            <scope>provided</scope>
+            <scope>${pmd.module.scope}</scope>
         </dependency>
         <dependency>
             <groupId>net.sourceforge.pmd</groupId>
             <artifactId>pmd-modelica</artifactId>
             <version>${pmd.core.version}</version>
             <optional>true</optional>
-            <scope>provided</scope>
+            <scope>${pmd.module.scope}</scope>
         </dependency>
 
         <!-- TEST DEPENDENCIES -->
@@ -680,158 +651,69 @@
 
     </dependencies>
 
-    <!-- Those profiles are activated when importing project in eclipse or IntelliJ-->
-    <!-- They're only there to shift the "provided" scope to "runtime", to avoid recording -->
-    <!-- accidental compile dependencies. -->
-    <!-- They're duplicated, because Maven doesn't support doing a logical OR in activation... -->
-    <!-- See https://issues.apache.org/jira/browse/MNG-3328 -->
     <profiles>
         <profile>
-            <id>m2e</id>
-            <!-- This profile is only activated when building in Eclipse with m2e -->
-            <activation>
-                <property>
-                    <name>m2e.version</name>
-                </property>
-            </activation>
+            <id>shading</id>
+            <!-- This profile is NOT active by default, so that import
+                 in IDEs work properly. This is the one to use to build
+                 the JAR that is included in the PMD's distribution.
+
+                 Do not use in conjunction with -Prunning.
+                 -->
+            <properties>
+                <!-- Marks those modules as "provided" to exclude them from the shaded jar -->
+                <!-- pmd-core is handled separately below -->
+                <pmd.module.scope>provided</pmd.module.scope>
+                <openjfx.scope>provided</openjfx.scope>
+            </properties>
+            <build>
+                <plugins>
+
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-shade-plugin</artifactId>
+                        <version>3.2.1</version>
+                        <configuration>
+
+                            <!-- We can't just use an artifactSet/excludes to exclude pmd dependencies -->
+                            <!-- because it would include their transitive dependencies -->
+
+                            <relocations>
+                                <!-- Relocate apache dependencies because they're included in the binary dist-->
+                                <relocation>
+                                    <pattern>org.apache.commons</pattern>
+                                    <shadedPattern>org.shaded.apache.commons</shadedPattern>
+                                </relocation>
+                            </relocations>
+
+                            <!-- Merge resource provider files like Ikonli icon resolvers -->
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                            </transformers>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>shade</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                </plugins>
+            </build>
             <dependencies>
                 <dependency>
                     <groupId>net.sourceforge.pmd</groupId>
                     <artifactId>pmd-core</artifactId>
                     <version>${pmd.core.version}</version>
-                    <scope>compile</scope>
-                </dependency>
-                <dependency>
-                    <groupId>net.sourceforge.pmd</groupId>
-                    <artifactId>pmd-apex</artifactId>
-                    <version>${pmd.core.version}</version>
-                    <optional>true</optional>
-                    <scope>runtime</scope>
-                </dependency>
-                <dependency>
-                    <groupId>net.sourceforge.pmd</groupId>
-                    <artifactId>pmd-java</artifactId>
-                    <version>${pmd.core.version}</version>
-                    <optional>true</optional>
-                    <scope>runtime</scope>
-                </dependency>
-                <dependency>
-                    <groupId>net.sourceforge.pmd</groupId>
-                    <artifactId>pmd-javascript</artifactId>
-                    <version>${pmd.core.version}</version>
-                    <optional>true</optional>
-                    <scope>runtime</scope>
-                </dependency>
-                <dependency>
-                    <groupId>net.sourceforge.pmd</groupId>
-                    <artifactId>pmd-jsp</artifactId>
-                    <version>${pmd.core.version}</version>
-                    <optional>true</optional>
-                    <scope>runtime</scope>
-                </dependency>
-                <dependency>
-                    <groupId>net.sourceforge.pmd</groupId>
-                    <artifactId>pmd-plsql</artifactId>
-                    <version>${pmd.core.version}</version>
-                    <optional>true</optional>
-                    <scope>runtime</scope>
-                </dependency>
-                <dependency>
-                    <groupId>net.sourceforge.pmd</groupId>
-                    <artifactId>pmd-visualforce</artifactId>
-                    <version>${pmd.core.version}</version>
-                    <optional>true</optional>
-                    <scope>runtime</scope>
-                </dependency>
-                <dependency>
-                    <groupId>net.sourceforge.pmd</groupId>
-                    <artifactId>pmd-vm</artifactId>
-                    <version>${pmd.core.version}</version>
-                    <optional>true</optional>
-                    <scope>runtime</scope>
-                </dependency>
-                <dependency>
-                    <groupId>net.sourceforge.pmd</groupId>
-                    <artifactId>pmd-xml</artifactId>
-                    <version>${pmd.core.version}</version>
-                    <optional>true</optional>
-                    <scope>runtime</scope>
+                    <!-- Marks pmd-core modules as "provided" to exclude them from the shaded jar -->
+                    <scope>provided</scope>
                 </dependency>
             </dependencies>
         </profile>
-        <profile>
-            <id>idea</id>
-            <!-- This profile is only activated when building in IntelliJ -->
-            <activation>
-                <property>
-                    <name>idea.maven.embedder.version</name>
-                </property>
-            </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>net.sourceforge.pmd</groupId>
-                    <artifactId>pmd-core</artifactId>
-                    <version>${pmd.core.version}</version>
-                    <scope>compile</scope>
-                </dependency>
-                <dependency>
-                    <groupId>net.sourceforge.pmd</groupId>
-                    <artifactId>pmd-apex</artifactId>
-                    <version>${pmd.core.version}</version>
-                    <optional>true</optional>
-                    <scope>runtime</scope>
-                </dependency>
-                <dependency>
-                    <groupId>net.sourceforge.pmd</groupId>
-                    <artifactId>pmd-java</artifactId>
-                    <version>${pmd.core.version}</version>
-                    <optional>true</optional>
-                    <scope>runtime</scope>
-                </dependency>
-                <dependency>
-                    <groupId>net.sourceforge.pmd</groupId>
-                    <artifactId>pmd-javascript</artifactId>
-                    <version>${pmd.core.version}</version>
-                    <optional>true</optional>
-                    <scope>runtime</scope>
-                </dependency>
-                <dependency>
-                    <groupId>net.sourceforge.pmd</groupId>
-                    <artifactId>pmd-jsp</artifactId>
-                    <version>${pmd.core.version}</version>
-                    <optional>true</optional>
-                    <scope>runtime</scope>
-                </dependency>
-                <dependency>
-                    <groupId>net.sourceforge.pmd</groupId>
-                    <artifactId>pmd-plsql</artifactId>
-                    <version>${pmd.core.version}</version>
-                    <optional>true</optional>
-                    <scope>runtime</scope>
-                </dependency>
-                <dependency>
-                    <groupId>net.sourceforge.pmd</groupId>
-                    <artifactId>pmd-visualforce</artifactId>
-                    <version>${pmd.core.version}</version>
-                    <optional>true</optional>
-                    <scope>runtime</scope>
-                </dependency>
-                <dependency>
-                    <groupId>net.sourceforge.pmd</groupId>
-                    <artifactId>pmd-vm</artifactId>
-                    <version>${pmd.core.version}</version>
-                    <optional>true</optional>
-                    <scope>runtime</scope>
-                </dependency>
-                <dependency>
-                    <groupId>net.sourceforge.pmd</groupId>
-                    <artifactId>pmd-xml</artifactId>
-                    <version>${pmd.core.version}</version>
-                    <optional>true</optional>
-                    <scope>runtime</scope>
-                </dependency>
-            </dependencies>
-        </profile>
+
         <profile>
             <id>release</id>
             <build>
@@ -853,6 +735,41 @@
                 </plugins>
             </build>
         </profile>
+
+        <profile>
+            <!-- This is a runnable profile that includes all pmd modules -->
+            <id>running</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>3.0.0</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>java</goal>
+                                </goals>
+                                <phase>deploy</phase>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <mainClass>net.sourceforge.pmd.util.fxdesigner.DesignerStarter</mainClass>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <!-- This profile adds openjfx dependencies to the classpath -->
+            <!-- Eg use -Prun,with-javafx -->
+            <id>with-javafx</id>
+            <properties>
+                <openjfx.scope>runtime</openjfx.scope>
+            </properties>
+        </profile>
+
     </profiles>
 
 </project>


### PR DESCRIPTION
The idea comes from https://github.com/pmd/pmd/pull/2597#discussion_r442042655

One can now launch the designer in two new ways:
* `./mvnw -Prunning exec:java`
* `./mvnw -Prunning,with-javafx exec:java`, which includes javafx dependencies in case you don't have a javafx distribution on your system

This also reorganises the current profiles. The default behavior for now is to produce a shaded Jar, with all pmd dependencies excluded ("provided" scope). This is now done with a profile (`-Pshading`) that is not active by default. The default behavior now is to have the pmd-dependencies as compile/runtime scope, which is what works best to import the project in an IDE. So we can remove the two huge profiles for ide import.

