### PR TITLE
Usability improvements

### DIFF
--- a/src/main/java/net/sourceforge/pmd/util/fxdesigner/util/controls/TestCaseListCell.java
+++ b/src/main/java/net/sourceforge/pmd/util/fxdesigner/util/controls/TestCaseListCell.java
@@ -45,7 +45,6 @@ import javafx.scene.layout.Background;
 import javafx.scene.layout.BackgroundFill;
 import javafx.scene.layout.CornerRadii;
 import javafx.scene.layout.HBox;
-import javafx.scene.layout.Pane;
 import javafx.scene.layout.Priority;
 import javafx.scene.paint.Color;
 import javafx.util.Duration;
@@ -66,7 +65,7 @@ public class TestCaseListCell extends SmartTextFieldListCell<LiveTestCase> {
     @Override
     protected Pair<Node, Subscription> getNonEditingGraphic(LiveTestCase testCase) {
         HBox hBox = new HBox();
-        hBox.setSpacing(10);
+        hBox.setSpacing(5);
 
         FontIcon statusIcon = new FontIcon();
         Label statusLabel = new Label();
@@ -99,13 +98,6 @@ public class TestCaseListCell extends SmartTextFieldListCell<LiveTestCase> {
                                        }
                                    });
 
-
-        Label descriptionLabel = new Label();
-
-        ControlUtil.bindLabelPropertyWithDefault(descriptionLabel, "(no description)", testCase.descriptionProperty());
-
-        ControlUtil.registerDoubleClickListener(descriptionLabel, this::doStartEdit);
-
         Button editDescription = new Button();
         editDescription.setGraphic(new FontIcon("far-edit"));
         editDescription.getStyleClass().addAll("edit-test-description", "icon-button");
@@ -113,20 +105,27 @@ public class TestCaseListCell extends SmartTextFieldListCell<LiveTestCase> {
         editDescription.setOnAction(e1 -> doStartEdit());
         sub = sub.and(() -> editDescription.setOnAction(null));
 
-        Pane spacer = new Pane();
-        HBox.setHgrow(spacer, Priority.ALWAYS);
+        Label descriptionLabel = new Label();
+        ControlUtil.bindLabelPropertyWithDefault(descriptionLabel, "(no description)", testCase.descriptionProperty());
+
+        HBox descriptionPane = new HBox();
+        descriptionPane.getChildren().addAll(editDescription, descriptionLabel);
+        descriptionPane.setAlignment(Pos.CENTER_LEFT);
+        descriptionPane.setSpacing(2);
+        HBox.setHgrow(descriptionPane, Priority.ALWAYS);
+        ControlUtil.registerDoubleClickListener(descriptionPane, this::doStartEdit);
 
         Button duplicate = new Button();
         duplicate.setGraphic(new FontIcon("far-copy"));
         duplicate.getStyleClass().addAll("duplicate-test", "icon-button");
-        Tooltip.install(duplicate, new Tooltip("Copy test case"));
+        Tooltip.install(duplicate, new Tooltip("Duplicate test case"));
         duplicate.setOnAction(e1 -> collection.duplicate(testCase));
         sub = sub.and(() -> duplicate.setOnAction(null));
 
 
         ToggleButton load = new ToggleButton();
         load.setToggleGroup(collection.getLoadedToggleGroup());
-        load.setGraphic(new FontIcon("fas-external-link-alt"));
+        load.setGraphic(new FontIcon("far-file-code"));
         load.getStyleClass().addAll("load-button", "icon-button");
         Tooltip.install(load, new Tooltip("Load test case in editor"));
 
@@ -154,10 +153,7 @@ public class TestCaseListCell extends SmartTextFieldListCell<LiveTestCase> {
         Tooltip.install(delete, new Tooltip("Remove test case"));
         delete.setOnAction(e -> collection.deleteTestCase(testCase));
 
-        ControlUtil.registerDoubleClickListener(spacer, load::fire);
-
-
-        hBox.getChildren().setAll(statusLabel, descriptionLabel, editDescription, spacer, delete, duplicate, load);
+        hBox.getChildren().setAll(statusLabel, descriptionPane, delete, duplicate, load);
         hBox.setAlignment(Pos.CENTER_LEFT);
 
 

--- a/src/main/resources/net/sourceforge/pmd/util/fxdesigner/fxml/editor.fxml
+++ b/src/main/resources/net/sourceforge/pmd/util/fxdesigner/fxml/editor.fxml
@@ -17,6 +17,7 @@
 <?import javafx.scene.control.Tooltip?>
 <?import javafx.scene.layout.AnchorPane?>
 <?import javafx.scene.layout.BorderPane?>
+<?import javafx.scene.shape.SVGPath?>
 <BorderPane xmlns="http://javafx.com/javafx/8"
             xmlns:fx="http://javafx.com/fxml/1"
             fx:controller="net.sourceforge.pmd.util.fxdesigner.SourceEditorController">
@@ -116,7 +117,11 @@
                                 </Button>
                                 <Button fx:id="exportTreeButton" styleClass="icon-button">
                                     <graphic>
-                                        <FontIcon iconLiteral="fas-external-link-alt"/>
+                                    	<!--Needs FA 5.1.0 -->
+					                    <!--<FontIcon iconLiteral="fas-file-export" />-->
+					                    <SVGPath styleClass="svg-icon"
+					                             scaleX="0.024" scaleY="0.024"
+					                             content="M384 121.9c0-6.3-2.5-12.4-7-16.9L279.1 7c-4.5-4.5-10.6-7-17-7H256v128h128v-6.1zM192 336v-32c0-8.84 7.16-16 16-16h176V160H248c-13.2 0-24-10.8-24-24V0H24C10.7 0 0 10.7 0 24v464c0 13.3 10.7 24 24 24h336c13.3 0 24-10.7 24-24V352H208c-8.84 0-16-7.16-16-16zm379.05-28.02l-95.7-96.43c-10.06-10.14-27.36-3.01-27.36 11.27V288H384v64h63.99v65.18c0 14.28 17.29 21.41 27.36 11.27l95.7-96.42c6.6-6.66 6.6-17.4 0-24.05z"/>
                                     </graphic>
                                     <tooltip>
                                         <Tooltip text="Export tree..."/>

--- a/src/main/resources/net/sourceforge/pmd/util/fxdesigner/less/tests.less
+++ b/src/main/resources/net/sourceforge/pmd/util/fxdesigner/less/tests.less
@@ -16,6 +16,7 @@
       .status-label {
         -fx-background-color: white;
         -fx-background-radius: 12;
+		-fx-padding: 0 1;
       }
 
       .test-status {
@@ -65,6 +66,16 @@
   }
 }
 
+.list-view .list-cell,
+.list-view:focused .list-cell:selected {
+  .icon-button.edit-test-description {
+    .force-square(16);
+
+    .ikonli-font-icon {
+      -fx-icon-size: 10;
+    }
+  }
+}
 
 .button.node-drag-over, .button:node-drag-possible-target {
 

--- a/src/main/resources/net/sourceforge/pmd/util/fxdesigner/less/tests.less
+++ b/src/main/resources/net/sourceforge/pmd/util/fxdesigner/less/tests.less
@@ -16,7 +16,7 @@
       .status-label {
         -fx-background-color: white;
         -fx-background-radius: 12;
-		-fx-padding: 0 1;
+        -fx-padding: 0 1;
       }
 
       .test-status {
@@ -101,4 +101,3 @@
     -fx-padding: 0 10 0 0;
   }
 }
-


### PR DESCRIPTION
 - The export AST now uses the same icon as other exports
 - The edit test code button now uses a more descriptive icon
 - The edit test name button is now smaller and to the left to keep them
all aligned
 - The duplicate test tooltip text is improved
 - The border around test status no longer fades around the sides

Before | After
-----|-----
![image](https://user-images.githubusercontent.com/802626/124700433-1fe4a800-dec3-11eb-9c0a-fb07057021e0.png) | ![image](https://user-images.githubusercontent.com/802626/124700676-7fdb4e80-dec3-11eb-9383-d6e78fb06952.png)
![image](https://user-images.githubusercontent.com/802626/124700551-4efb1980-dec3-11eb-8c1d-678b6ef909c2.png) | ![image](https://user-images.githubusercontent.com/802626/124700696-8b2e7a00-dec3-11eb-9945-9a1f149c778b.png)

I also made double click on test rows more predictable. The old behaviour was:

- double click the label => change name
- double click the whitespace right of the edit button (but not the 10px at the end of the whitespace) => load the test code (I actually only figured this one out reading the code… this whitespace may actually be 0px wide if the test name is long enough…)
- double click the 10px at the edged of the whitespace (safe zone) => nothing

The new behaviour is:
- double click anywhere between test status and delete button (except the 5px around the edges) => change the name
- double click the 5px at the edges (safe zone) => nothing

