### PR TITLE
Better expose entry points for pmd-cli integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,6 +95,11 @@ buildNumber.properties
 
 # End of https://www.gitignore.io/api/intellij,maven
 
+### Eclipse ###
+.project
+.settings
+.classpath
+
 .idea/*
 # Share run configurations for easier setup
 !/.idea/runConfigurations/

--- a/src/main/java/net/sourceforge/pmd/util/fxdesigner/Designer.java
+++ b/src/main/java/net/sourceforge/pmd/util/fxdesigner/Designer.java
@@ -12,6 +12,12 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
+import net.sourceforge.pmd.lang.ast.xpath.Attribute;
+import net.sourceforge.pmd.util.fxdesigner.app.DesignerParams;
+import net.sourceforge.pmd.util.fxdesigner.app.DesignerRoot;
+import net.sourceforge.pmd.util.fxdesigner.app.DesignerRootImpl;
+import net.sourceforge.pmd.util.fxdesigner.util.DesignerUtil;
+
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.collections.ObservableList;
@@ -20,11 +26,6 @@ import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.scene.image.Image;
 import javafx.stage.Stage;
-import net.sourceforge.pmd.lang.ast.xpath.Attribute;
-import net.sourceforge.pmd.util.fxdesigner.app.DesignerParams;
-import net.sourceforge.pmd.util.fxdesigner.app.DesignerRoot;
-import net.sourceforge.pmd.util.fxdesigner.app.DesignerRootImpl;
-import net.sourceforge.pmd.util.fxdesigner.util.DesignerUtil;
 
 
 /**

--- a/src/main/java/net/sourceforge/pmd/util/fxdesigner/Designer.java
+++ b/src/main/java/net/sourceforge/pmd/util/fxdesigner/Designer.java
@@ -5,23 +5,12 @@
 package net.sourceforge.pmd.util.fxdesigner;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
-import java.util.Properties;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
-
-import net.sourceforge.pmd.PMDVersion;
-import net.sourceforge.pmd.lang.ast.xpath.Attribute;
-import net.sourceforge.pmd.util.fxdesigner.app.DesignerParams;
-import net.sourceforge.pmd.util.fxdesigner.app.DesignerRoot;
-import net.sourceforge.pmd.util.fxdesigner.app.DesignerRootImpl;
-import net.sourceforge.pmd.util.fxdesigner.util.DesignerUtil;
-import net.sourceforge.pmd.util.fxdesigner.util.ResourceUtil;
 
 import javafx.application.Application;
 import javafx.application.Platform;
@@ -31,6 +20,11 @@ import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.scene.image.Image;
 import javafx.stage.Stage;
+import net.sourceforge.pmd.lang.ast.xpath.Attribute;
+import net.sourceforge.pmd.util.fxdesigner.app.DesignerParams;
+import net.sourceforge.pmd.util.fxdesigner.app.DesignerRoot;
+import net.sourceforge.pmd.util.fxdesigner.app.DesignerRootImpl;
+import net.sourceforge.pmd.util.fxdesigner.util.DesignerUtil;
 
 
 /**
@@ -40,44 +34,6 @@ import javafx.stage.Stage;
  * @since 6.0.0
  */
 public class Designer extends Application {
-
-    /**
-     * Constant that contains always the current version of the designer.
-     */
-    private static final String VERSION;
-    private static final String PMD_CORE_MIN_VERSION;
-    private static final String UNKNOWN_VERSION = "unknown";
-
-
-    /**
-     * Determines the version from maven's generated pom.properties file.
-     */
-    static {
-        VERSION = readProperty("/META-INF/maven/net.sourceforge.pmd/pmd-ui/pom.properties", "version").orElse(UNKNOWN_VERSION);
-        PMD_CORE_MIN_VERSION = readProperty(ResourceUtil.resolveResource("designer.properties"), "pmd.core.version").orElse(UNKNOWN_VERSION);
-    }
-
-
-    public static String getCurrentVersion() {
-        return VERSION;
-    }
-
-    public static String getPmdCoreMinVersion() {
-        return PMD_CORE_MIN_VERSION;
-    }
-
-    private static Optional<String> readProperty(String resourcePath, String key) {
-        try (InputStream stream = PMDVersion.class.getResourceAsStream(resourcePath)) {
-            if (stream != null) {
-                final Properties properties = new Properties();
-                properties.load(stream);
-                return Optional.ofNullable(properties.getProperty(key));
-            }
-        } catch (final IOException ignored) {
-            // fallthrough
-        }
-        return Optional.empty();
-    }
 
     private long initStartTimeMillis;
     private DesignerRoot designerRoot;
@@ -101,7 +57,7 @@ public class Designer extends Application {
     public void start(Stage stage, DesignerRoot owner) throws IOException {
         this.designerRoot = owner;
 
-        stage.setTitle("PMD Rule Designer (v " + Designer.VERSION + ')');
+        stage.setTitle("PMD Rule Designer (v " + DesignerVersion.getCurrentVersion() + ')');
         setIcons(stage);
 
         Logger.getLogger(Attribute.class.getName()).setLevel(Level.OFF);

--- a/src/main/java/net/sourceforge/pmd/util/fxdesigner/DesignerStarter.java
+++ b/src/main/java/net/sourceforge/pmd/util/fxdesigner/DesignerStarter.java
@@ -87,7 +87,8 @@ public final class DesignerStarter {
 
         readParameters(args);
 
-        launchGui(args);
+        final int ret = launchGui(args);
+        System.exit(ret);
     }
 
     private static void setSystemProperties() {

--- a/src/main/java/net/sourceforge/pmd/util/fxdesigner/DesignerStarter.java
+++ b/src/main/java/net/sourceforge/pmd/util/fxdesigner/DesignerStarter.java
@@ -11,6 +11,8 @@ import javax.swing.JOptionPane;
 
 import org.apache.commons.lang3.SystemUtils;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.ParameterException;
 import javafx.application.Application;
@@ -47,7 +49,7 @@ public final class DesignerStarter {
         }
     }
 
-
+    @Deprecated
     private static MainCliArgs readParameters(String[] argv) {
 
         MainCliArgs argsObj = new MainCliArgs();
@@ -75,7 +77,12 @@ public final class DesignerStarter {
 
     }
 
-
+    /**
+     * Starting from PMD 7.0.0 this method usage will be limited for development.
+     * CLI support will be provided by pmd-cli
+     */
+    @Deprecated
+    @InternalApi
     public static void main(String[] args) {
 
         readParameters(args);
@@ -118,6 +125,7 @@ public final class DesignerStarter {
         return null;
     }
 
+    @Deprecated
     private static String getHelpText(JCommander jCommander) {
 
         StringBuilder sb = new StringBuilder();
@@ -139,7 +147,7 @@ public final class DesignerStarter {
     }
 
     @SuppressWarnings("PMD.AvoidCatchingThrowable")
-    private static void launchGui(String[] args) {
+    public static int launchGui(String[] args) {
         setSystemProperties();
 
         String message = null;
@@ -152,14 +160,16 @@ public final class DesignerStarter {
         if (message != null) {
             System.err.println(message);
             JOptionPane.showMessageDialog(null, message);
-            System.exit(ERROR_EXIT);
+            return ERROR_EXIT;
         }
 
         try {
             Application.launch(Designer.class, args);
         } catch (Throwable unrecoverable) {
             unrecoverable.printStackTrace();
-            System.exit(ERROR_EXIT);
+            return ERROR_EXIT;
         }
+
+        return OK;
     }
 }

--- a/src/main/java/net/sourceforge/pmd/util/fxdesigner/DesignerStarter.java
+++ b/src/main/java/net/sourceforge/pmd/util/fxdesigner/DesignerStarter.java
@@ -34,9 +34,6 @@ public final class DesignerStarter {
 
     private static final int MIN_JAVAFX_VERSION_ON_MAC_OSX = 14;
 
-    private static final int ERROR_EXIT = 1;
-    private static final int OK = 0;
-
     private DesignerStarter() {
     }
 
@@ -61,7 +58,7 @@ public final class DesignerStarter {
 
             if (argsObj.help) {
                 System.out.println(getHelpText(jCommander));
-                System.exit(OK);
+                System.exit(ExitStatus.OK.getCode());
             }
 
             return argsObj;
@@ -70,7 +67,7 @@ public final class DesignerStarter {
             System.out.println(e.getMessage());
             System.out.println();
             System.out.println(getHelpText(jCommander));
-            System.exit(OK);
+            System.exit(ExitStatus.OK.getCode());
             throw new AssertionError();
         }
 
@@ -81,14 +78,13 @@ public final class DesignerStarter {
      * Starting from PMD 7.0.0 this method usage will be limited for development.
      * CLI support will be provided by pmd-cli
      */
-    @Deprecated
     @InternalApi
     public static void main(String[] args) {
 
         readParameters(args);
 
-        final int ret = launchGui(args);
-        System.exit(ret);
+        final ExitStatus ret = launchGui(args);
+        System.exit(ret.getCode());
     }
 
     private static void setSystemProperties() {
@@ -148,7 +144,7 @@ public final class DesignerStarter {
     }
 
     @SuppressWarnings("PMD.AvoidCatchingThrowable")
-    public static int launchGui(String[] args) {
+    public static ExitStatus launchGui(String[] args) {
         setSystemProperties();
 
         String message = null;
@@ -161,16 +157,31 @@ public final class DesignerStarter {
         if (message != null) {
             System.err.println(message);
             JOptionPane.showMessageDialog(null, message);
-            return ERROR_EXIT;
+            return ExitStatus.ERROR;
         }
 
         try {
             Application.launch(Designer.class, args);
         } catch (Throwable unrecoverable) {
             unrecoverable.printStackTrace();
-            return ERROR_EXIT;
+            return ExitStatus.ERROR;
         }
 
-        return OK;
+        return ExitStatus.OK;
+    }
+
+    public enum ExitStatus {
+        OK(0),
+        ERROR(1);
+
+        private final int code;
+
+        ExitStatus(final int code) {
+            this.code = code;
+        }
+
+        public int getCode() {
+            return code;
+        }
     }
 }

--- a/src/main/java/net/sourceforge/pmd/util/fxdesigner/DesignerVersion.java
+++ b/src/main/java/net/sourceforge/pmd/util/fxdesigner/DesignerVersion.java
@@ -1,0 +1,59 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.util.fxdesigner;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Optional;
+import java.util.Properties;
+
+import net.sourceforge.pmd.PMDVersion;
+import net.sourceforge.pmd.util.fxdesigner.util.ResourceUtil;
+
+/**
+ * Stores the current Designer and PMD version and provides utility methods around them.
+ */
+public class DesignerVersion {
+
+    /**
+     * Constant that contains always the current version of the designer.
+     */
+    private static final String VERSION;
+    private static final String PMD_CORE_MIN_VERSION;
+    private static final String UNKNOWN_VERSION = "unknown";
+
+    /**
+     * Determines the version from maven's generated pom.properties file.
+     */
+    static {
+        VERSION = readProperty("/META-INF/maven/net.sourceforge.pmd/pmd-ui/pom.properties", "version").orElse(UNKNOWN_VERSION);
+        PMD_CORE_MIN_VERSION = readProperty(ResourceUtil.resolveResource("designer.properties"), "pmd.core.version").orElse(UNKNOWN_VERSION);
+    }
+
+    private DesignerVersion() {
+        throw new AssertionError("Can't instantiate a utility class.");
+    }
+
+    public static String getCurrentVersion() {
+        return VERSION;
+    }
+
+    public static String getPmdCoreMinVersion() {
+        return PMD_CORE_MIN_VERSION;
+    }
+
+    private static Optional<String> readProperty(String resourcePath, String key) {
+        try (InputStream stream = PMDVersion.class.getResourceAsStream(resourcePath)) {
+            if (stream != null) {
+                final Properties properties = new Properties();
+                properties.load(stream);
+                return Optional.ofNullable(properties.getProperty(key));
+            }
+        } catch (final IOException ignored) {
+            // fallthrough
+        }
+        return Optional.empty();
+    }
+}

--- a/src/main/java/net/sourceforge/pmd/util/fxdesigner/DesignerVersion.java
+++ b/src/main/java/net/sourceforge/pmd/util/fxdesigner/DesignerVersion.java
@@ -15,7 +15,7 @@ import net.sourceforge.pmd.util.fxdesigner.util.ResourceUtil;
 /**
  * Stores the current Designer and PMD version and provides utility methods around them.
  */
-public class DesignerVersion {
+public final class DesignerVersion {
 
     /**
      * Constant that contains always the current version of the designer.

--- a/src/main/java/net/sourceforge/pmd/util/fxdesigner/MainCliArgs.java
+++ b/src/main/java/net/sourceforge/pmd/util/fxdesigner/MainCliArgs.java
@@ -6,10 +6,11 @@ package net.sourceforge.pmd.util.fxdesigner;
 
 import com.beust.jcommander.Parameter;
 
+@Deprecated
 final class MainCliArgs {
 
 
-    @Parameter(names = {"--verbose", "-v"},
+    @Parameter(names = {"--verbose", "-v", "-D", "--debug"},
                arity = 0,
                description = "Whether to launch the app in verbose mode. "
                    + "This enables logging of exception stack traces and "

--- a/src/main/java/net/sourceforge/pmd/util/fxdesigner/app/DesignerParams.java
+++ b/src/main/java/net/sourceforge/pmd/util/fxdesigner/app/DesignerParams.java
@@ -9,6 +9,7 @@ import java.nio.file.Paths;
 import java.util.List;
 
 import com.sun.javafx.application.ParametersImpl;
+
 import javafx.application.Application.Parameters;
 
 
@@ -42,7 +43,7 @@ public final class DesignerParams {
     public DesignerParams(Parameters params) {
         List<String> raw = params.getRaw();
         // error output is disabled by default
-        if (raw.contains("-v") || raw.contains("--verbose")) {
+        if (raw.contains("-v") || raw.contains("--verbose") || raw.contains("--debug") || raw.contains("-D")) {
             isDeveloperMode = true;
         }
 

--- a/src/main/java/net/sourceforge/pmd/util/fxdesigner/app/DesignerParams.java
+++ b/src/main/java/net/sourceforge/pmd/util/fxdesigner/app/DesignerParams.java
@@ -9,7 +9,6 @@ import java.nio.file.Paths;
 import java.util.List;
 
 import com.sun.javafx.application.ParametersImpl;
-
 import javafx.application.Application.Parameters;
 
 

--- a/src/main/java/net/sourceforge/pmd/util/fxdesigner/app/services/GlobalDiskManagerImpl.java
+++ b/src/main/java/net/sourceforge/pmd/util/fxdesigner/app/services/GlobalDiskManagerImpl.java
@@ -11,7 +11,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import net.sourceforge.pmd.util.fxdesigner.Designer;
+import net.sourceforge.pmd.util.fxdesigner.DesignerVersion;
 import net.sourceforge.pmd.util.fxdesigner.app.ApplicationComponent;
 import net.sourceforge.pmd.util.fxdesigner.app.DesignerRoot;
 
@@ -33,7 +33,7 @@ public class GlobalDiskManagerImpl implements GlobalDiskManager, ApplicationComp
         this.settingsDirectory = settingsDirectory;
 
 
-        Path curVersionStamp = settingsDirectory.resolve("version-" + Designer.getCurrentVersion());
+        Path curVersionStamp = settingsDirectory.resolve("version-" + DesignerVersion.getCurrentVersion());
 
 
         List<Path> diskVersionStamps = getDiskVersionStamps();
@@ -62,7 +62,7 @@ public class GlobalDiskManagerImpl implements GlobalDiskManager, ApplicationComp
                         .filter(it -> !Files.isDirectory(it))
                         .filter(it -> it.getFileName().toString().startsWith(STAMP_PREFIX))
                         .collect(Collectors.toList());
-        } catch (IOException e) {
+        } catch (IOException ignored) {
             return Collections.emptyList();
         }
     }

--- a/src/main/java/net/sourceforge/pmd/util/fxdesigner/app/services/OnDiskPersistenceManager.java
+++ b/src/main/java/net/sourceforge/pmd/util/fxdesigner/app/services/OnDiskPersistenceManager.java
@@ -9,7 +9,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.CompletableFuture;
 
-import net.sourceforge.pmd.util.fxdesigner.Designer;
+import net.sourceforge.pmd.util.fxdesigner.DesignerVersion;
 import net.sourceforge.pmd.util.fxdesigner.app.DesignerRoot;
 import net.sourceforge.pmd.util.fxdesigner.util.beans.SettingsOwner;
 import net.sourceforge.pmd.util.fxdesigner.util.beans.SettingsPersistenceUtil;
@@ -85,7 +85,7 @@ public class OnDiskPersistenceManager implements PersistenceManager {
         process.start().waitFor();
         process.command("git", "add", output.toString());
         process.start().waitFor();
-        process.command("git", "commit", "-m", "\"On version " + Designer.getCurrentVersion() + "\"");
+        process.command("git", "commit", "-m", "\"On version " + DesignerVersion.getCurrentVersion() + "\"");
         process.start().waitFor();
 
     }

--- a/src/main/java/net/sourceforge/pmd/util/fxdesigner/popups/SimplePopups.java
+++ b/src/main/java/net/sourceforge/pmd/util/fxdesigner/popups/SimplePopups.java
@@ -19,13 +19,6 @@ import org.kordamp.ikonli.javafx.FontIcon;
 import org.reactfx.EventSource;
 import org.reactfx.EventStream;
 
-import net.sourceforge.pmd.PMDVersion;
-import net.sourceforge.pmd.lang.Language;
-import net.sourceforge.pmd.util.fxdesigner.Designer;
-import net.sourceforge.pmd.util.fxdesigner.app.DesignerRoot;
-import net.sourceforge.pmd.util.fxdesigner.util.AuxLanguageRegistry;
-import net.sourceforge.pmd.util.fxdesigner.util.DesignerUtil;
-
 import javafx.animation.Animation;
 import javafx.animation.Interpolator;
 import javafx.animation.Transition;
@@ -39,6 +32,12 @@ import javafx.scene.control.TextArea;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Popup;
 import javafx.util.Duration;
+import net.sourceforge.pmd.PMDVersion;
+import net.sourceforge.pmd.lang.Language;
+import net.sourceforge.pmd.util.fxdesigner.DesignerVersion;
+import net.sourceforge.pmd.util.fxdesigner.app.DesignerRoot;
+import net.sourceforge.pmd.util.fxdesigner.util.AuxLanguageRegistry;
+import net.sourceforge.pmd.util.fxdesigner.util.DesignerUtil;
 
 
 /**
@@ -213,8 +212,8 @@ public final class SimplePopups {
 
         String sb =
             "PMD core version:\t\t\t" + PMDVersion.VERSION + "\n"
-                + "Designer version:\t\t\t" + Designer.getCurrentVersion()
-                + " (supports PMD core " + Designer.getPmdCoreMinVersion() + ")\n"
+                + "Designer version:\t\t\t" + DesignerVersion.getCurrentVersion()
+                + " (supports PMD core " + DesignerVersion.getPmdCoreMinVersion() + ")\n"
                 + "Designer settings dir:\t\t"
                 + root.getService(DesignerRoot.DISK_MANAGER).getSettingsDirectory() + "\n"
                 + "Available languages:\t\t"

--- a/src/main/java/net/sourceforge/pmd/util/fxdesigner/popups/SimplePopups.java
+++ b/src/main/java/net/sourceforge/pmd/util/fxdesigner/popups/SimplePopups.java
@@ -19,6 +19,13 @@ import org.kordamp.ikonli.javafx.FontIcon;
 import org.reactfx.EventSource;
 import org.reactfx.EventStream;
 
+import net.sourceforge.pmd.PMDVersion;
+import net.sourceforge.pmd.lang.Language;
+import net.sourceforge.pmd.util.fxdesigner.DesignerVersion;
+import net.sourceforge.pmd.util.fxdesigner.app.DesignerRoot;
+import net.sourceforge.pmd.util.fxdesigner.util.AuxLanguageRegistry;
+import net.sourceforge.pmd.util.fxdesigner.util.DesignerUtil;
+
 import javafx.animation.Animation;
 import javafx.animation.Interpolator;
 import javafx.animation.Transition;
@@ -32,12 +39,6 @@ import javafx.scene.control.TextArea;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Popup;
 import javafx.util.Duration;
-import net.sourceforge.pmd.PMDVersion;
-import net.sourceforge.pmd.lang.Language;
-import net.sourceforge.pmd.util.fxdesigner.DesignerVersion;
-import net.sourceforge.pmd.util.fxdesigner.app.DesignerRoot;
-import net.sourceforge.pmd.util.fxdesigner.util.AuxLanguageRegistry;
-import net.sourceforge.pmd.util.fxdesigner.util.DesignerUtil;
 
 
 /**


### PR DESCRIPTION
- Introduce `DesignerVersion` as a standalone equivalent of `PMDVersion`. By having access to this POJO outside of `Designer` it's possible to for pmd-cli to show the designer version (through `$ pmd designer --version`) without requiring JavaFX to be available.
- Expose `DesignerStarter.startGui` so that pmd-cli can invoke it. Have it return the exit code vs performing a `System.exit` on it's own.
- Deprecate all internal usages of JCommander, and mark the main as an internal (development) utility.
- Have development mode enabled not only through `-v` and `--verbose`, but also through `-D` and `--debug` for compatibility with all other pmd commands supported in pmd-cli.