### PR TITLE
Expose all properties with default values

### DIFF
--- a/src/main/java/net/sourceforge/pmd/util/fxdesigner/model/XPathEvaluator.java
+++ b/src/main/java/net/sourceforge/pmd/util/fxdesigner/model/XPathEvaluator.java
@@ -10,6 +10,7 @@ import static java.util.Collections.emptyMap;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
@@ -83,10 +84,11 @@ public final class XPathEvaluator {
 
         try {
 
-            Map<String, ? extends PropertyDescriptor<?>> descriptors = properties.stream().collect(Collectors.toMap(PropertyDescriptorSpec::getName, PropertyDescriptorSpec::build));
+            Map<String, PropertyDescriptor<?>> descriptors = properties.stream().collect(Collectors.toMap(PropertyDescriptorSpec::getName, PropertyDescriptorSpec::build));
+            // Take in all set values or defaults
             Map<PropertyDescriptor<?>, Object> allProperties =
-                propertyValues.entrySet().stream()
-                              .collect(Collectors.toMap(e -> descriptors.get(e.getKey()), e -> descriptors.get(e.getKey()).valueFrom(e.getValue())));
+                descriptors.entrySet().stream()
+                              .collect(Collectors.<Entry<String, PropertyDescriptor<?>>, PropertyDescriptor<?>, Object>toMap(e -> e.getValue(), e -> propertyValues.containsKey(e.getKey()) ? e.getValue().valueFrom(propertyValues.get(e.getKey())) : e.getValue().defaultValue()));
 
             SaxonXPathRuleQuery xpathRule =
                 new SaxonXPathRuleQuery(


### PR DESCRIPTION
 - The current implementation was leaving out any property without a set value instead of taking the default, so any rule defining and using a property would throw a syntax error.
 - Notice that there is no way to set property values for testing. The values of `AstManagerImpl.ruleProperties()` are never set nor bound to anything. This was probably intended to be exposed in the UI as a way to test the rule with different values / taken from each test case configuration, but neither was ever implemented. This is still pending.

Before:

<img width="1203" alt="image" src="https://github.com/pmd/pmd-designer/assets/802626/0c5c83a4-a813-4781-979f-018519a7e92c">

After:

<img width="1197" alt="image" src="https://github.com/pmd/pmd-designer/assets/802626/28c35fc1-59c0-4d52-9675-286b8ea8211a">

