### PR TITLE
Correctly determine JavaFX version when embedded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [#61](https://github.com/pmd/pmd-designer/issues/61) Remove dependency to jcommander
 * [#62](https://github.com/pmd/pmd-designer/issues/62) Exceptions and errors are not always logged
 * [#63](https://github.com/pmd/pmd-designer/issues/63) Update to PMD 7.0.0-rc3
+* [#72](https://github.com/pmd/pmd-designer/issues/72) NPE when launching Designer
 
 **Merged pull requests:**
 

--- a/src/main/java/net/sourceforge/pmd/util/fxdesigner/DesignerStarter.java
+++ b/src/main/java/net/sourceforge/pmd/util/fxdesigner/DesignerStarter.java
@@ -4,12 +4,11 @@
 
 package net.sourceforge.pmd.util.fxdesigner;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Properties;
-import javax.swing.JOptionPane;
+import static net.sourceforge.pmd.util.fxdesigner.util.JavaFxUtil.isCompatibleJavaFxVersion;
+import static net.sourceforge.pmd.util.fxdesigner.util.JavaFxUtil.isJavaFxAvailable;
+import static net.sourceforge.pmd.util.fxdesigner.util.JavaFxUtil.setSystemProperties;
 
-import org.apache.commons.lang3.SystemUtils;
+import javax.swing.JOptionPane;
 
 import net.sourceforge.pmd.annotation.InternalApi;
 
@@ -30,18 +29,7 @@ public final class DesignerStarter {
             + " Please install the latest JavaFX on your system and try again." + System.lineSeparator()
             + " See https://gluonhq.com/products/javafx/";
 
-    private static final int MIN_JAVAFX_VERSION_ON_MAC_OSX = 14;
-
     private DesignerStarter() {
-    }
-
-    private static boolean isJavaFxAvailable() {
-        try {
-            DesignerStarter.class.getClassLoader().loadClass("javafx.application.Application");
-            return true;
-        } catch (ClassNotFoundException | LinkageError e) {
-            return false;
-        }
     }
 
     /**
@@ -52,41 +40,6 @@ public final class DesignerStarter {
     public static void main(String[] args) {
         final ExitStatus ret = launchGui(args);
         System.exit(ret.getCode());
-    }
-
-    private static void setSystemProperties() {
-        if (SystemUtils.IS_OS_LINUX) {
-            // On Linux, JavaFX renders text poorly by default. These settings help to alleviate the problems.
-            System.setProperty("prism.text", "t2k");
-            System.setProperty("prism.lcdtext", "true");
-        }
-    }
-    
-    private static boolean isCompatibleJavaFxVersion() {
-        if (SystemUtils.IS_OS_MAC_OSX) {
-            final String javaFxVersion = getJavaFxVersion();
-            if (javaFxVersion != null) {
-                final int major = Integer.parseInt(javaFxVersion.split("\\.")[0]);
-                if (major < MIN_JAVAFX_VERSION_ON_MAC_OSX) {
-                    // Prior to JavaFx 14, text on Mac OSX was garbled and unreadable
-                    return false;
-                }
-            }
-        }
-
-        return true;
-    }
-
-    private static String getJavaFxVersion() {
-        try (InputStream is = DesignerStarter.class.getClassLoader().getResourceAsStream("javafx.properties")) {
-            final Properties javaFxProperties = new Properties();
-            javaFxProperties.load(is);
-            return (String) javaFxProperties.get("javafx.version");
-        } catch (IOException ignored) {
-            // Can't determine the version
-        }
-
-        return null;
     }
 
     @SuppressWarnings("PMD.AvoidCatchingThrowable")

--- a/src/main/java/net/sourceforge/pmd/util/fxdesigner/popups/SimplePopups.java
+++ b/src/main/java/net/sourceforge/pmd/util/fxdesigner/popups/SimplePopups.java
@@ -25,6 +25,7 @@ import net.sourceforge.pmd.util.fxdesigner.DesignerVersion;
 import net.sourceforge.pmd.util.fxdesigner.app.DesignerRoot;
 import net.sourceforge.pmd.util.fxdesigner.util.AuxLanguageRegistry;
 import net.sourceforge.pmd.util.fxdesigner.util.DesignerUtil;
+import net.sourceforge.pmd.util.fxdesigner.util.JavaFxUtil;
 
 import javafx.animation.Animation;
 import javafx.animation.Interpolator;
@@ -212,14 +213,17 @@ public final class SimplePopups {
         TextArea textArea = new TextArea();
 
         String sb =
-            "PMD core version:\t\t\t" + PMDVersion.VERSION + "\n"
+            "PMD core version:\t\t" + PMDVersion.VERSION + "\n"
                 + "Designer version:\t\t\t" + DesignerVersion.getCurrentVersion()
                 + " (supports PMD core " + DesignerVersion.getPmdCoreMinVersion() + ")\n"
                 + "Designer settings dir:\t\t"
                 + root.getService(DesignerRoot.DISK_MANAGER).getSettingsDirectory() + "\n"
                 + "Available languages:\t\t"
                 + AuxLanguageRegistry.getSupportedLanguages().map(Language::getTerseName).collect(Collectors.toList())
-                + "\n";
+                + "\n"
+                + "\n"
+                + "Java Version:\t\t\t\t" + System.getProperty("java.version") + " (" + System.getProperty("java.vendor") + ")\n"
+                + "JavaFX Version:\t\t\t" + JavaFxUtil.getJavaFxVersion() + "\n";
 
         textArea.setText(sb);
         scroll.setContent(textArea);

--- a/src/main/java/net/sourceforge/pmd/util/fxdesigner/util/JavaFxUtil.java
+++ b/src/main/java/net/sourceforge/pmd/util/fxdesigner/util/JavaFxUtil.java
@@ -1,0 +1,94 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.util.fxdesigner.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Properties;
+
+import org.apache.commons.lang3.SystemUtils;
+
+import javafx.application.Application;
+
+public final class JavaFxUtil {
+    private static final int MIN_JAVAFX_VERSION_ON_MAC_OSX = 14;
+
+    private JavaFxUtil() {
+    }
+
+    public static boolean isJavaFxAvailable() {
+        try {
+            JavaFxUtil.class.getClassLoader().loadClass("javafx.application.Application");
+            return true;
+        } catch (ClassNotFoundException | LinkageError e) {
+            return false;
+        }
+    }
+
+    public static String getJavaFxVersion() {
+        InputStream javafxProperties = JavaFxUtil.class.getClassLoader().getResourceAsStream("javafx.properties");
+
+        if (javafxProperties == null) {
+            try {
+                Path path = Paths.get(Application.class.getProtectionDomain().getCodeSource().getLocation().toURI());
+                Path propertiesFile1 = path.resolveSibling("javafx.properties");
+                Path propertiesFile2 = path.getParent().getParent().resolve("javafx.properties");
+                if (Files.exists(propertiesFile1)) {
+                    javafxProperties = Files.newInputStream(propertiesFile1);
+                } else if (Files.exists(propertiesFile2)) {
+                    javafxProperties = Files.newInputStream(propertiesFile2);
+                }
+            } catch (URISyntaxException | IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        if (javafxProperties != null) {
+            try (InputStream is = javafxProperties) {
+                final Properties javaFxProperties = new Properties();
+                javaFxProperties.load(is);
+                String javaFxVersion = javaFxProperties.getProperty("javafx.version");
+                if (javaFxVersion != null) {
+                    return javaFxVersion;
+                }
+                return javaFxProperties.getProperty("javafx.runtime.version");
+            } catch (IOException ignored) {
+                // Can't determine the version
+                System.err.println("Can't determine javafx version: " + ignored);
+            }
+        } else {
+            System.err.println("Can't determine javafx version: javafx.properties not found in classpath.");
+        }
+        return null;
+    }
+
+    public static void setSystemProperties() {
+        if (SystemUtils.IS_OS_LINUX) {
+            // On Linux, JavaFX renders text poorly by default. These settings help to alleviate the problems.
+            System.setProperty("prism.text", "t2k");
+            System.setProperty("prism.lcdtext", "true");
+        }
+    }
+
+
+    public static boolean isCompatibleJavaFxVersion() {
+        if (SystemUtils.IS_OS_MAC_OSX) {
+            final String javaFxVersion = getJavaFxVersion();
+            if (javaFxVersion != null) {
+                final int major = Integer.parseInt(javaFxVersion.split("\\.")[0]);
+                if (major < MIN_JAVAFX_VERSION_ON_MAC_OSX) {
+                    // Prior to JavaFx 14, text on Mac OSX was garbled and unreadable
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
Fixes #72

It also displays the java version and javafx version in "Help > About".

I've tested it with openjdk-17 (adoptium) + openjfx17 and oracle-java-8 (which contains an embedded javafx 8).

Note: The designer doesn't work with azul openjdk which also includes openjfx. See also #71.