### PR TITLE
Properly stringify collection attributes as sequences

### DIFF
--- a/src/main/java/net/sourceforge/pmd/util/fxdesigner/util/DesignerUtil.java
+++ b/src/main/java/net/sourceforge/pmd/util/fxdesigner/util/DesignerUtil.java
@@ -8,6 +8,7 @@ import java.io.PrintStream;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -411,14 +412,21 @@ public final class DesignerUtil {
 
 
     public static String attrToXpathString(Attribute attr) {
-        String stringValue = attr.getStringValue();
-        Object v = attr.getValue();
+        return valueToXPathString(attr.getValue(), attr.getStringValue());
+    }
+
+    private static String valueToXPathString(Object v, String stringValue) {
         if (v instanceof String || v instanceof Enum) {
-            stringValue = "\"" + StringEscapeUtils.escapeJava(stringValue) + "\"";
+            return "\"" + StringEscapeUtils.escapeJava(stringValue) + "\"";
         } else if (v instanceof Boolean) {
-            stringValue = v + "()";
+            return v + "()";
+        } else if (v instanceof Collection) {
+            return ((Collection<?>) v).stream()
+                    .map(o -> valueToXPathString(o, String.valueOf(o)))
+                    .collect(Collectors.joining(", ", "(", ")"));
         }
-        return String.valueOf(stringValue);
+
+        return String.valueOf(v);
     }
 
 


### PR DESCRIPTION
Previous designer versions would work, but show collections as `["first", "second"]`, but proper sequences use parentheses as `("first", "second")`.

We don't need to force the designer to work against a new PMD version, it just works regardless of the version in use.

- Refs https://github.com/pmd/pmd/issues/4467
- Refs https://github.com/pmd/pmd/pull/4969


Before:
![image](https://github.com/pmd/pmd-designer/assets/1573684/adf7bd43-b3ec-45cc-bbe9-7aee3b9d4e2b)

After:
![image](https://github.com/pmd/pmd-designer/assets/1573684/fae8844c-b599-492d-85e0-b11e8e71c3e6)
