### PR TITLE
Refactor GitHub Actions Workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,54 +1,53 @@
-name: build
+name: Build
 on:
+  pull_request:
+  merge_group:
   push:
     branches:
-      - main
+      - '**'
+      # don't run on dependabot branches. Dependabot will create pull requests, which will then be run instead
+      - '!dependabot/**'
     tags:
       - '**'
-  pull_request:
+  workflow_dispatch:
   schedule:
     # build it monthly: At 05:00 on day-of-month 1.
     - cron:  '0 5 1 * *'
-  workflow_dispatch:
+
+# if another commit is added to the same branch or PR (same github.ref),
+# then cancel already running jobs and start a new build.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
+env:
+  LANG: 'en_US.UTF-8'
 
 jobs:
-  build:
+  compile:
     runs-on: ubuntu-latest
-    continue-on-error: false
-    if: ${{ !contains(github.event.head_commit.message, '[skip ci]') }}
+    timeout-minutes: 10
+    defaults:
+      run:
+        shell: bash
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/cache@v4
-      with:
-        path: |
-          ~/.m2/repository
-          ~/.cache
-        key: ${{ runner.os }}-${{ hashFiles('**/pom.xml') }}
-        restore-keys: |
-          ${{ runner.os }}-
-    - name: Set up Ruby 3.3
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: 3.3
-    - name: Setup Environment
-      shell: bash
-      run: |
-        echo "LANG=en_US.UTF-8" >> $GITHUB_ENV
-        echo "MAVEN_OPTS=-Dmaven.wagon.httpconnectionManager.ttlSeconds=180 -Dmaven.wagon.http.retryHandler.count=3" >> $GITHUB_ENV
-        echo "PMD_CI_SCRIPTS_URL=https://raw.githubusercontent.com/pmd/build-tools/30/scripts" >> $GITHUB_ENV
-    - name: Check Environment
-      shell: bash
-      run: |
-        f=check-environment.sh; \
-        mkdir -p .ci && \
-        ( [ -e .ci/$f ] || curl -sSL "${PMD_CI_SCRIPTS_URL}/$f" > ".ci/$f" ) && \
-        chmod 755 .ci/$f && \
-        .ci/$f
-    - name: Build
-      run: .ci/build.sh
-      shell: bash
-      env:
-        PMD_CI_SECRET_PASSPHRASE: ${{ secrets.PMD_CI_SECRET_PASSPHRASE }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        PMD_CI_GPG_PRIVATE_KEY: ${{ secrets.PMD_CI_GPG_PRIVATE_KEY }}
-        MAVEN_GPG_PASSPHRASE: ${{ secrets.PMD_CI_GPG_PASSPHRASE }}
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+          cache: 'maven'
+      - name: Build with Maven
+        run: |
+          ./mvnw --show-version --errors --batch-mode \
+              -Pshading \
+              verify
+      - uses: actions/upload-artifact@v4
+        with:
+          name: compile-artifact
+          if-no-files-found: error
+          path: |
+            target/pmd-designer-*.jar

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -21,7 +21,7 @@ jobs:
     # only run in the official pmd/pmd-designer repo, where we have access to the secrets and not on forks
     # and only run for _successful_ push workflow runs on tags.
     if: ${{ github.repository == 'pmd/designer'
-      && github.event.workflow_run.event == 'push'
+      && contains(fromJSON('["push", "workflow_dispatch"]'), github.event.workflow_run.event)
       && github.event.workflow_run.head_branch != 'main'
       && github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -57,6 +57,22 @@ jobs:
             exit 1
           fi
           echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
+      - name: Add Job Summary
+        env:
+          WORKFLOW_RUN_DISPLAY_TITLE: ${{ github.event.workflow_run.display_title }}
+          WORKFLOW_RUN_NAME: ${{ github.event.workflow_run.name }}
+          WORKFLOW_RUN_NUMBER: ${{ github.event.workflow_run.run_number }}
+          WORKFLOW_RUN_HTML_URL: ${{ github.event.workflow_run.html_url }}
+          VERSION: ${{ steps.version.outputs.VERSION }}
+          TAG: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          echo "### Run Info" >> "${GITHUB_STEP_SUMMARY}"
+          echo "Building Version: ${VERSION}" >> "${GITHUB_STEP_SUMMARY}"
+          echo "" >> "${GITHUB_STEP_SUMMARY}"
+          echo "Tag: ${TAG}" >> "${GITHUB_STEP_SUMMARY}"
+          echo "" >> "${GITHUB_STEP_SUMMARY}"
+          echo "Called by [${WORKFLOW_RUN_DISPLAY_TITLE} (${WORKFLOW_RUN_NAME} #${WORKFLOW_RUN_NUMBER})](${WORKFLOW_RUN_HTML_URL})" >> "${GITHUB_STEP_SUMMARY}"
+          echo "" >> "${GITHUB_STEP_SUMMARY}"
 
   deploy-to-maven-central:
     needs: check-version

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,114 @@
+name: Publish Release
+
+on:
+  workflow_run:
+    workflows: [Build]
+    types:
+      - completed
+    branches:
+      - '**'
+      - '!main'
+      - '!dependabot/**'
+
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
+env:
+  LANG: 'en_US.UTF-8'
+
+jobs:
+  check-version:
+    # only run in the official pmd/pmd-designer repo, where we have access to the secrets and not on forks
+    # and only run for _successful_ push workflow runs on tags.
+    if: ${{ github.repository == 'pmd/designer'
+      && github.event.workflow_run.event == 'push'
+      && github.event.workflow_run.head_branch != 'main'
+      && github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        shell: bash
+    outputs:
+      VERSION: ${{ steps.version.outputs.VERSION }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_branch }}
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+          cache: 'maven'
+      - name: Determine Version
+        id: version
+        env:
+          REF: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          if ! git show-ref --exists "refs/tags/$REF"; then
+            echo "::error ::Tag $REF does not exist, aborting."
+            exit 1
+          fi
+          
+          VERSION=$(./mvnw --batch-mode --no-transfer-progress help:evaluate -Dexpression=project.version -q -DforceStdout)
+          echo "Determined VERSION=$VERSION"
+          if [[ "$VERSION" = *-SNAPSHOT ]]; then
+            echo "::error ::VERSION=$VERSION is a snapshot version, aborting."
+            exit 1
+          fi
+          echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
+
+  deploy-to-maven-central:
+    needs: check-version
+    # use environment maven-central, where secrets are configured for OSSRH_*
+    environment:
+      name: maven-central
+      url: https://repo.maven.apache.org/maven2/net/sourceforge/pmd/pmd-designer/
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: write # to create a new release
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_branch }}
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+          cache: 'maven'
+          server-id: ossrh
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+          gpg-private-key: ${{ secrets.PMD_CI_GPG_PRIVATE_KEY }}
+      - name: Build and Publish
+        env:
+          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.PMD_CI_GPG_PASSPHRASE }}
+        run: |
+          ./mvnw --show-version --errors --batch-mode \
+            -Psign,shading \
+            deploy
+      - name: Prepare Release Notes
+        run: |
+          BEGIN_LINE=$(grep -n "^## " CHANGELOG.md|head -1|cut -d ":" -f 1)
+          BEGIN_LINE=$((BEGIN_LINE + 1))
+          END_LINE=$(grep -n "^## " CHANGELOG.md|head -2|tail -1|cut -d ":" -f 1)
+          END_LINE=$((END_LINE - 1))
+          RELEASE_BODY="$(head -$END_LINE CHANGELOG.md | tail -$((END_LINE - BEGIN_LINE)))"
+          echo "$RELEASE_BODY" > release_notes.md
+      - name: Create Release
+        env:
+          TAG_NAME: ${{ github.event.workflow_run.head_branch }}
+          VERSION: ${{ needs.check-version.outputs.VERSION }}
+        run: |
+          # Note: The release asset is the shaded jar
+          gh release create "$TAG_NAME" "target/pmd-designer-${VERSION}.jar" \
+              --verify-tag \
+              --notes-file release_notes.md \
+              --title "$VERSION"

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -48,6 +48,22 @@ jobs:
             exit 1
           fi
           echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
+      - name: Add Job Summary
+        env:
+          WORKFLOW_RUN_DISPLAY_TITLE: ${{ github.event.workflow_run.display_title }}
+          WORKFLOW_RUN_NAME: ${{ github.event.workflow_run.name }}
+          WORKFLOW_RUN_NUMBER: ${{ github.event.workflow_run.run_number }}
+          WORKFLOW_RUN_HTML_URL: ${{ github.event.workflow_run.html_url }}
+          VERSION: ${{ steps.version.outputs.VERSION }}
+          BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          echo "### Run Info" >> "${GITHUB_STEP_SUMMARY}"
+          echo "Building Version: ${VERSION}" >> "${GITHUB_STEP_SUMMARY}"
+          echo "" >> "${GITHUB_STEP_SUMMARY}"
+          echo "Branch: ${BRANCH}" >> "${GITHUB_STEP_SUMMARY}"
+          echo "" >> "${GITHUB_STEP_SUMMARY}"
+          echo "Called by [${WORKFLOW_RUN_DISPLAY_TITLE} (${WORKFLOW_RUN_NAME} #${WORKFLOW_RUN_NUMBER})](${WORKFLOW_RUN_HTML_URL})" >> "${GITHUB_STEP_SUMMARY}"
+          echo "" >> "${GITHUB_STEP_SUMMARY}"
 
   deploy-to-maven-central:
     needs: check-version

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -1,0 +1,85 @@
+name: Publish Snapshot
+
+on:
+  workflow_run:
+    workflows: [Build]
+    types:
+      - completed
+    branches:
+      - main
+
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
+env:
+  LANG: 'en_US.UTF-8'
+
+jobs:
+  check-version:
+    # only run in the official pmd/pmd-designer repo, where we have access to the secrets and not on forks
+    # and only run for _successful_ push workflow runs on branch "main".
+    if: ${{ github.repository == 'pmd/pmd-designer'
+      && github.event.workflow_run.event == 'push'
+      && github.event.workflow_run.head_branch == 'main'
+      && github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        shell: bash
+    outputs:
+      VERSION: ${{ steps.version.outputs.VERSION }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+          cache: 'maven'
+      - name: Determine Version
+        id: version
+        run: |
+          VERSION=$(./mvnw --batch-mode --no-transfer-progress help:evaluate -Dexpression=project.version -q -DforceStdout)
+          echo "Determined VERSION=$VERSION"
+          if [[ "$VERSION" != *-SNAPSHOT ]]; then
+            echo "::error ::VERSION=$VERSION is not a snapshot version, aborting."
+            exit 1
+          fi
+          echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
+
+  deploy-to-maven-central:
+    needs: check-version
+    # use environment maven-central, where secrets are configured for OSSRH_*
+    environment:
+      name: maven-central
+      url: https://oss.sonatype.org/content/repositories/snapshots/net/sourceforge/pmd/pmd-designer/
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+          cache: 'maven'
+          server-id: ossrh
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+          gpg-private-key: ${{ secrets.PMD_CI_GPG_PRIVATE_KEY }}
+      - name: Build and Publish
+        env:
+          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.PMD_CI_GPG_PASSPHRASE }}
+        run: |
+          ./mvnw --show-version --errors --batch-mode \
+              -Psign,shading \
+              deploy

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -19,7 +19,7 @@ jobs:
     # only run in the official pmd/pmd-designer repo, where we have access to the secrets and not on forks
     # and only run for _successful_ push workflow runs on branch "main".
     if: ${{ github.repository == 'pmd/pmd-designer'
-      && github.event.workflow_run.event == 'push'
+      && contains(fromJSON('["push", "workflow_dispatch", "schedule"]'), github.event.workflow_run.event)
       && github.event.workflow_run.head_branch == 'main'
       && github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
Don't rely on shell scripts from build-tools anymore. Main build.yml can be run on forks, as it doesn't need any secrets. Use two additional workflows for snapshots and releases.

Similar to pmd/build-tools#68
Refs pmd/pmd#4328