### PR TITLE
[ci] Make build a reuseable workflow

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -1,0 +1,11 @@
+name: Build Pull Request
+
+on:
+  pull_request:
+  merge_group:
+    types: [checks_requested]
+
+jobs:
+  build:
+    name: Build Pull Request
+    uses: ./.github/workflows/build.yml

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,0 +1,12 @@
+name: Build Release
+
+on:
+  push:
+    tags:
+      - '**'
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build Release
+    uses: ./.github/workflows/build.yml

--- a/.github/workflows/build-snapshot.yml
+++ b/.github/workflows/build-snapshot.yml
@@ -1,0 +1,17 @@
+name: Build Snapshot
+
+on:
+  push:
+    branches:
+      - '**'
+      # don't run on dependabot branches. Dependabot will create pull requests, which will then be run instead
+      - '!dependabot/**'
+  workflow_dispatch:
+  schedule:
+    # build it monthly: At 05:00 on day-of-month 1.
+    - cron:  '0 5 1 * *'
+
+jobs:
+  build:
+    name: Build Snapshot
+    uses: ./.github/workflows/build.yml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,18 +1,6 @@
 name: Build
 on:
-  pull_request:
-  merge_group:
-  push:
-    branches:
-      - '**'
-      # don't run on dependabot branches. Dependabot will create pull requests, which will then be run instead
-      - '!dependabot/**'
-    tags:
-      - '**'
-  workflow_dispatch:
-  schedule:
-    # build it monthly: At 05:00 on day-of-month 1.
-    - cron:  '0 5 1 * *'
+  workflow_call:
 
 # if another commit is added to the same branch or PR (same github.ref),
 # then cancel already running jobs and start a new build.

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -2,7 +2,7 @@ name: Publish Release
 
 on:
   workflow_run:
-    workflows: [Build]
+    workflows: [Build Release]
     types:
       - completed
     branches:

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -2,7 +2,7 @@ name: Publish Snapshot
 
 on:
   workflow_run:
-    workflows: [Build]
+    workflows: [Build Snapshot]
     types:
       - completed
     branches:


### PR DESCRIPTION
This should avoid triggering unnecessary publish-* workflows, as we can now filter on the events beforehand.
The additional filter is still kept for additional safety.

Refs https://github.com/pmd/pmd/issues/4328