### PR TITLE
chore: Use PmdAnalysis to execute PMD for parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 **✨️ Merged pull requests:**
 * [#316](https://github.com/pmd/pmd-designer/pull/316): chore: Use Java 21 for builds - [Andreas Dangel](https://github.com/adangel) (@adangel)
 * [#319](https://github.com/pmd/pmd-designer/pull/319): chore: Avoid using classpath classloader for auxclasspath - [Andreas Dangel](https://github.com/adangel) (@adangel)
+* [#376](https://github.com/pmd/pmd-designer/pull/376): chore: Use PmdAnalysis to execute PMD for parsing - [Andreas Dangel](https://github.com/adangel) (@adangel)
 
 **📦️ Dependency updates:**
 

--- a/src/main/java/net/sourceforge/pmd/util/fxdesigner/app/services/ASTManagerImpl.java
+++ b/src/main/java/net/sourceforge/pmd/util/fxdesigner/app/services/ASTManagerImpl.java
@@ -9,8 +9,6 @@ import static net.sourceforge.pmd.util.fxdesigner.util.reactfx.ReactfxUtil.lates
 import static net.sourceforge.pmd.util.fxdesigner.util.reactfx.VetoableEventStream.vetoableNull;
 
 import java.io.File;
-import java.io.InputStream;
-import java.net.URL;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
@@ -22,7 +20,6 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.reactfx.util.Either;
 import org.reactfx.value.SuspendableVar;
 import org.reactfx.value.Val;
@@ -30,7 +27,6 @@ import org.reactfx.value.Var;
 
 import net.sourceforge.pmd.PMDConfiguration;
 import net.sourceforge.pmd.PmdAnalysis;
-import net.sourceforge.pmd.lang.JvmLanguagePropertyBundle;
 import net.sourceforge.pmd.lang.Language;
 import net.sourceforge.pmd.lang.LanguageProcessor;
 import net.sourceforge.pmd.lang.LanguageProcessorRegistry;
@@ -95,15 +91,13 @@ public class ASTManagerImpl implements ASTManager {
                   .or(classpathProperty().values())
                   .or(languageVersionProperty().values())
                   .subscribe(tick -> {
-                      // note: if either of these values would be null
-                      // the optional is empty.
-                      Optional<List<ClasspathEntry>> changedClasspath = tick.asLeft().filter(Either::isRight).map(Either::getRight);
+                      // note: if either of these values would be null the optional is empty.
                       Optional<LanguageVersion> changedLanguageVersion = Optional.of(tick).filter(Either::isRight).map(Either::getRight);
 
                       Node updated;
                       try {
                           updated = refreshAST(this, getSourceCode(), getLanguageVersion(),
-                                  refreshRegistry(changedLanguageVersion.isPresent(), changedClasspath.isPresent()),
+                                  refreshRegistry(changedLanguageVersion.isPresent()),
                                   classpathProperty().getValue()).orElse(null);
                           currentException.setValue(null);
                       } catch (ParseAbortedException e) {
@@ -211,17 +205,13 @@ public class ASTManagerImpl implements ASTManager {
         return currentException;
     }
 
-    private LanguageProcessorRegistry createNewRegistry(LanguageVersion version, List<ClasspathEntry> classpath) {
+    // Note: This registry is used via languageProcessorProperty() to get access
+    // to DesignerBindings. It doesn't have and need the auxClasspath configuration.
+    // It is not used for generating the AST, see refreshAST() for that.
+    private LanguageProcessorRegistry createNewRegistry(LanguageVersion version) {
         Map<Language, LanguagePropertyBundle> langProperties = new HashMap<>();
         LanguagePropertyBundle bundle = version.getLanguage().newPropertyBundle();
         bundle.setLanguageVersion(version.getVersion());
-        if (bundle instanceof JvmLanguagePropertyBundle) {
-            bundle.setProperty(JvmLanguagePropertyBundle.AUX_CLASSPATH,
-                classpath.stream()
-                    .map(ClasspathEntry::getEntry)
-                    .collect(Collectors.joining(File.pathSeparator)));
-        }
-
         langProperties.put(version.getLanguage(), bundle);
 
         LanguageRegistry languages =
@@ -233,9 +223,9 @@ public class ASTManagerImpl implements ASTManager {
                 NOOP_REPORTER);
     }
 
-    private LanguageProcessorRegistry refreshRegistry(boolean changedLanguageVersion, boolean changedClassLoader) {
+    private LanguageProcessorRegistry refreshRegistry(boolean changedLanguageVersion) {
         LanguageProcessorRegistry current = lpRegistry.getValue();
-        if (current != null && !changedLanguageVersion && !changedClassLoader) {
+        if (current != null && !changedLanguageVersion) {
             // the current one is fine
             return current;
         }
@@ -245,7 +235,7 @@ public class ASTManagerImpl implements ASTManager {
             current.close();
         }
 
-        LanguageProcessorRegistry newRegistry = createNewRegistry(getLanguageVersion(), classpathProperty().getValue());
+        LanguageProcessorRegistry newRegistry = createNewRegistry(getLanguageVersion());
         lpRegistry.setValue(newRegistry);
         return newRegistry;
     }
@@ -304,7 +294,7 @@ public class ASTManagerImpl implements ASTManager {
             }
 
             // Notify that the parse went OK so we can avoid logging very recent exceptions
-            component.raiseParsableSourceFlag(() -> "Param hash: " + Objects.hash(source, version, lpRegistry));
+            component.raiseParsableSourceFlag(() -> "Param hash: " + Objects.hash(source, version, classpath));
 
             return Optional.ofNullable(rule.getRootNode());
         }

--- a/src/main/java/net/sourceforge/pmd/util/fxdesigner/app/services/ASTManagerImpl.java
+++ b/src/main/java/net/sourceforge/pmd/util/fxdesigner/app/services/ASTManagerImpl.java
@@ -9,6 +9,8 @@ import static net.sourceforge.pmd.util.fxdesigner.util.reactfx.ReactfxUtil.lates
 import static net.sourceforge.pmd.util.fxdesigner.util.reactfx.VetoableEventStream.vetoableNull;
 
 import java.io.File;
+import java.io.InputStream;
+import java.net.URL;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
@@ -20,11 +22,14 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.reactfx.util.Either;
 import org.reactfx.value.SuspendableVar;
 import org.reactfx.value.Val;
 import org.reactfx.value.Var;
 
+import net.sourceforge.pmd.PMDConfiguration;
+import net.sourceforge.pmd.PmdAnalysis;
 import net.sourceforge.pmd.lang.JvmLanguagePropertyBundle;
 import net.sourceforge.pmd.lang.Language;
 import net.sourceforge.pmd.lang.LanguageProcessor;
@@ -33,11 +38,12 @@ import net.sourceforge.pmd.lang.LanguagePropertyBundle;
 import net.sourceforge.pmd.lang.LanguageRegistry;
 import net.sourceforge.pmd.lang.LanguageVersion;
 import net.sourceforge.pmd.lang.ast.Node;
-import net.sourceforge.pmd.lang.ast.Parser.ParserTask;
-import net.sourceforge.pmd.lang.ast.RootNode;
-import net.sourceforge.pmd.lang.ast.SemanticErrorReporter;
 import net.sourceforge.pmd.lang.document.FileId;
 import net.sourceforge.pmd.lang.document.TextDocument;
+import net.sourceforge.pmd.lang.rule.AbstractRule;
+import net.sourceforge.pmd.lang.rule.RuleSet;
+import net.sourceforge.pmd.reporting.Report;
+import net.sourceforge.pmd.reporting.RuleContext;
 import net.sourceforge.pmd.util.fxdesigner.SourceEditorController;
 import net.sourceforge.pmd.util.fxdesigner.app.ApplicationComponent;
 import net.sourceforge.pmd.util.fxdesigner.app.DesignerRoot;
@@ -97,7 +103,8 @@ public class ASTManagerImpl implements ASTManager {
                       Node updated;
                       try {
                           updated = refreshAST(this, getSourceCode(), getLanguageVersion(),
-                                  refreshRegistry(changedLanguageVersion.isPresent(), changedClasspath.isPresent())).orElse(null);
+                                  refreshRegistry(changedLanguageVersion.isPresent(), changedClasspath.isPresent()),
+                                  classpathProperty().getValue()).orElse(null);
                           currentException.setValue(null);
                       } catch (ParseAbortedException e) {
                           updated = null;
@@ -243,6 +250,18 @@ public class ASTManagerImpl implements ASTManager {
         return newRegistry;
     }
 
+    public static class RootNodeCapturingRule extends AbstractRule {
+        private Node rootNode;
+
+        @Override
+        public void apply(Node target, RuleContext ctx) {
+            rootNode = target;
+        }
+
+        public Node getRootNode() {
+            return rootNode;
+        }
+    }
 
     /**
      * Refreshes the compilation unit given the current state of the model.
@@ -252,30 +271,42 @@ public class ASTManagerImpl implements ASTManager {
     private static Optional<Node> refreshAST(ApplicationComponent component,
                                              String source,
                                              LanguageVersion version,
-                                             LanguageProcessorRegistry lpRegistry) throws ParseAbortedException {
+                                             LanguageProcessorRegistry lpRegistry,
+                                             List<ClasspathEntry> classpath) throws ParseAbortedException {
+        PMDConfiguration config = new PMDConfiguration(lpRegistry.getLanguages());
+        config.setIgnoreIncrementalAnalysis(true);
+        config.setAnalysisCacheLocation(null);
+        config.setThreads(0); // important, so that the same RootNodeCapturingRule instance is used
+        config.setDefaultLanguageVersion(version);
 
-        String dummyFilePath = "dummy." + version.getLanguage().getExtensions().get(0);
-        TextDocument textDocument = TextDocument.readOnlyString(source, FileId.fromPathLikeString(dummyFilePath), version);
-
-        ParserTask task = new ParserTask(
-            textDocument,
-            SemanticErrorReporter.noop(),
-            lpRegistry
-        );
-
-        LanguageProcessor processor = lpRegistry.getProcessor(version.getLanguage());
-        RootNode node;
-        try {
-            node = processor.services().getParser().parse(task);
-        } catch (Exception e) {
-            component.logUserException(e, Category.PARSE_EXCEPTION);
-            throw new ParseAbortedException(e);
+        if (classpath != null && !classpath.isEmpty()) {
+            config.prependAuxClasspath(classpath.stream()
+                    .map(ClasspathEntry::getEntry)
+                    .collect(Collectors.joining(File.pathSeparator)));
         }
 
-        // Notify that the parse went OK so we can avoid logging very recent exceptions
+        RootNodeCapturingRule rule = new RootNodeCapturingRule();
+        rule.setLanguage(version.getLanguage());
 
-        component.raiseParsableSourceFlag(() -> "Param hash: " + Objects.hash(source, version, lpRegistry));
+        try (PmdAnalysis pmdAnalysis = PmdAnalysis.create(config)) {
+            pmdAnalysis.addRuleSet(RuleSet.forSingleRule(rule));
 
-        return Optional.of(node);
+            String dummyFilePath = "dummy." + version.getLanguage().getExtensions().get(0);
+            FileId fileId = FileId.fromPathLikeString(dummyFilePath);
+            pmdAnalysis.files().addSourceFile(fileId, source);
+
+            Report report = pmdAnalysis.performAnalysisAndCollectReport();
+
+            if (!report.getProcessingErrors().isEmpty()) {
+                Throwable e = report.getProcessingErrors().get(0).getError();
+                component.logUserException(e, Category.PARSE_EXCEPTION);
+                throw new ParseAbortedException(e);
+            }
+
+            // Notify that the parse went OK so we can avoid logging very recent exceptions
+            component.raiseParsableSourceFlag(() -> "Param hash: " + Objects.hash(source, version, lpRegistry));
+
+            return Optional.ofNullable(rule.getRootNode());
+        }
     }
 }


### PR DESCRIPTION
This PR changes, how PMD Designer call PMD - it uses the common programming interface via PmdAnalysis (https://docs.pmd-code.org/latest/pmd_userdocs_tools_java_api.html).

This now calls the full analysis including any language specific processing that might happen before the parsing stage. This is needed for upcoming Kotlin support (see pmd/pmd#6795).

~This is for now just a draft, needs to be combined with #319.~
